### PR TITLE
Fix select() wrapper issues

### DIFF
--- a/trickle-overload.c
+++ b/trickle-overload.c
@@ -393,18 +393,14 @@ select_delay(struct delayhead *dhead, struct sockdesc *sd, short which)
 }
 
 static struct delay *
-select_shift(struct delayhead *dhead, struct timeval *inittv,
+select_shift(struct delayhead *dhead, struct timeval *difftv,
     struct timeval **delaytv)
 {
-	struct timeval curtv, difftv;
 	struct delay *d;
 	struct sockdesc *sd;
 
-	gettimeofday(&curtv, NULL);
-	timersub(&curtv, inittv, &difftv);
-
 	TAILQ_FOREACH(d, dhead, next) {
-		if (timercmp(&d->delaytv, &difftv, >))
+		if (timercmp(&d->delaytv, difftv, >))
 			break;
 		sd = d->sd;
 
@@ -413,7 +409,7 @@ select_shift(struct delayhead *dhead, struct timeval *inittv,
 	}
 
 	if (d != NULL)
-		timersub(&d->delaytv, &difftv, *delaytv);
+		timersub(&d->delaytv, difftv, *delaytv);
 	else 
 		*delaytv = NULL;
 
@@ -431,8 +427,8 @@ _select(int nfds, fd_set *rfds, fd_set *wfds, fd_set *efds,
 {
 	struct sockdesc *sd;
 	fd_set *fdsets[] = { wfds, rfds }, *fds;
-	struct timeval *delaytv, *selecttv = NULL, *timeout = NULL, _timeout,
-	    inittv, curtv, difftv;
+	struct timeval *delaytv, _delaytv, *selecttv = NULL, *timeout = NULL,
+	    _timeout, inittv, curtv, difftv;
 	short which;
 	struct delayhead dhead;
 	struct delay *d, *_d;
@@ -462,15 +458,18 @@ _select(int nfds, fd_set *rfds, fd_set *wfds, fd_set *efds,
 			    FD_ISSET(sd->sock, fds) &&
 			    select_delay(&dhead, sd, which)) {
 				FD_CLR(sd->sock, fds);
-				nfds--;
 			}
 
 	gettimeofday(&inittv, NULL);
 	curtv = inittv;
 	d = TAILQ_FIRST(&dhead);
-	delaytv = d != NULL ? &d->delaytv : NULL;
+	if (d != NULL) {
+		_delaytv = d->delaytv;
+		delaytv = &_delaytv;
+	} else
+		delaytv = NULL;
+	timersub(&curtv, &inittv, &difftv);
  again:
-	timersub(&inittv, &curtv, &difftv);
 	selecttv = NULL;
 
 	if (delaytv != NULL)
@@ -498,15 +497,15 @@ _select(int nfds, fd_set *rfds, fd_set *wfds, fd_set *efds,
 #endif /* DEBUG */
 
 	if (ret == 0 && delaytv != NULL && selecttv == delaytv) {
-		_d = select_shift(&dhead, &inittv, &delaytv);
+		gettimeofday(&curtv, NULL);
+		timersub(&curtv, &inittv, &difftv);
+		_d = select_shift(&dhead, &difftv, &delaytv);
 		while ((d = TAILQ_FIRST(&dhead)) != _d) {
 			FD_SET(d->sd->sock, fdsets[d->which]);
-			nfds++;
 			TAILQ_REMOVE(&dhead, d, next);
 			free(d);
 		}
 
-		gettimeofday(&curtv, NULL);
 		goto again;
 	}
 


### PR DESCRIPTION
Problem #1

From man 3 select

The nfds argument specifies the range  of  descriptors  to  be  tested.
The  first  nfds
descriptors  shall  be  checked  in  each  set; that is, the descriptors
from zero through
nfds-1 in the descriptor sets shall be examined.

Hence in trickle-overload.c _select(), it is wrong to decrement nfds
because:

a) the same fd could be in both read & write fdsets but is counted only
once in nfds
b) in other words nfds is maxfd value in any fdsets passed in parameters
in the following scenario, the code as is would fail

   delayed socket fd = 1, fd = 2 is a local pipe not found in sdhead
tailq. nfds = 3

   current code would remove fd1 from fdset and decrement nfds to 2.
Hence libc_select will not consider fd2 at all.

There is no portable way to efficiently recalculate nfds once you remove
the highest fd from the sets.

The only portable way would be to use a for loop with an initial value
equal to nfds-1 up to 0 and test each bits with FD_ISSET until it
returns true.

A more efficient and non portable way would be to test for non 0 integer
in the fdset bitmap array and only test bit by bit once you find the
first
non zero integer but IMO, this is not worth the trouble. select syscall
will scan the fdset with the implementation knowledge in the most
efficient way.

My recommendation: just do not mess with nfds.

Problem #2:

delaytv points to the first dhead element delaytv. If this element gets
freed, this will result into invalid read and write when
accessing delaytv.

Problem #3:

timersub(&inittv, &curtv, &difftv);

should be

timersub(&curtv, &inittv, &difftv);

Improvement #1:

I have removed 1 gettimeofday system call and 1 difftv computation.

Signed-off-by: Olivier Langlois olivier@olivierlanglois.net
