### PR TITLE
Improve bwstat robustness

### DIFF
--- a/bwstat.c
+++ b/bwstat.c
@@ -69,6 +69,7 @@ bwstat_new(void)
 	if ((bs = calloc(1, sizeof(*bs))) == NULL)
 		return (NULL);
 
+	bs->pts = 1;
 	TAILQ_INSERT_TAIL(&statq, bs, next);
 
 	return (bs);
@@ -143,7 +144,8 @@ _bwstat_update(struct bwstat_data *bsd, size_t len)
 struct timeval *
 bwstat_getdelay(struct bwstat *bs, size_t *len, uint lim, short which)
 {
-	uint rate = 0, ncli = 0, npts = 0, pool = 0, ent, xent;
+	uint rate = 0, npts = 0, ent;
+	int ncli = 0, pool = 0, xent;
 	double delay;
 	static struct timeval tv;
 	struct bwstathead poolq;
@@ -201,7 +203,7 @@ bwstat_getdelay(struct bwstat *bs, size_t *len, uint lim, short which)
 		if (ncli > 0) {
 			xent = pool / npts;
 
-			if (xent == 0)
+			if (xent <= 0)
 				break;
 
 			TAILQ_FOREACH(xbs, &poolq, qnext)

--- a/trickle-overload.c
+++ b/trickle-overload.c
@@ -311,7 +311,6 @@ socket(int domain, int type, int protocol)
 		}
 
 		/* All sockets are equals. */
-		sd->stat->pts = 1;
 		sd->stat->lsmooth = lsmooth;
 		sd->stat->tsmooth = tsmooth;
 		sd->sock = sock;
@@ -993,7 +992,6 @@ accept(int sock, struct sockaddr *addr, socklen_t *addrlen)
 		}
 
 		sd->sock = ret;
-		sd->stat->pts = 1;
 		sd->stat->lsmooth = lsmooth;
 		sd->stat->tsmooth = tsmooth;
 		TAILQ_INSERT_TAIL(&sdhead, sd, next);


### PR DESCRIPTION
I got a program stuck into the loop inside bwstat_getdelay(). I believe that is
is due to the fact that I am using trickle in a multithread program and trickle
is not thread safe. Still, there 2 small things that can be done to improve
bwstat code:
1. Change pool,ncli and xent to detect overflow/underflow and quit the loop.
2. Initialize pts before inserting the new bwstat into the global list.

Signed-off-by: Olivier Langlois olivier@olivierlanglois.net
