### PR TITLE
Fix socket overload with ruby

### DIFF
--- a/trickle-overload.c
+++ b/trickle-overload.c
@@ -325,7 +325,7 @@ socket(int domain, int type, int protocol)
 	    domain, type, protocol, sock);
 #endif /* DEBUG */
 
-	if (sock != -1 && domain == AF_INET && type == SOCK_STREAM) {
+	if (sock != -1 && domain == AF_INET && type & SOCK_STREAM) {
 		if ((sd = calloc(1, sizeof(*sd))) == NULL)
 			return (-1);
 		trickle_lock();


### PR DESCRIPTION
ruby use SOCK_STREAM | SOCK_CLOEXEC

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=824513
https://unix.stackexchange.com/questions/268389/why-doesnt-rate-limiting-with-trickle-work-with-ruby