### PR TITLE
improve socket() to handle linux SOCK_NONBLOCK and SOCK_CLOEXEC flags

### DIFF
--- a/trickle-overload.c
+++ b/trickle-overload.c
@@ -325,6 +325,13 @@ socket(int domain, int type, int protocol)
 	    domain, type, protocol, sock);
 #endif /* DEBUG */
 
+#ifdef SOCK_NONBLOCK
+	type &= ~SOCK_NONBLOCK;
+#endif
+#ifdef SOCK_CLOEXEC
+	type &= ~SOCK_CLOEXEC;
+#endif
+
 	if (sock != -1 && domain == AF_INET && type == SOCK_STREAM) {
 		if ((sd = calloc(1, sizeof(*sd))) == NULL)
 			return (-1);


### PR DESCRIPTION
In Linux 2.6.27 new flags, SOCK_NONBLOCK and SOCK_CLOEXEC, were added. In this change I added proper support for those flags.